### PR TITLE
Add automation script for backend IAM provisioning

### DIFF
--- a/Backend_Setup_Steps.md
+++ b/Backend_Setup_Steps.md
@@ -1,0 +1,121 @@
+# Backend Deployment Steps for Asharvi Server
+
+The following guide assumes the front-end stack already uses IAM, S3, CloudFront, Lambda, and API Gateway. We will reuse IAM wherever possible and create dedicated backend resources (network, compute, database connectivity). All steps target **AWS ap-south-1 (Mumbai)**.
+
+---
+
+## 1. Validate Shared IAM Resources
+1. **Review existing IAM roles/policies**
+   - Confirm the front-end deployment role (e.g., `AsharviDeployRole`) has only the permissions it needs (CloudFront, S3, Lambda, API Gateway). Ensure no overly broad policies remain from initial provisioning.
+   - Ensure MFA is enforced for human users. Update password policies if missing.
+2. **Create/confirm backend-specific IAM roles**
+   - **`AsharviBackendEcsTaskRole`** – Allows `secretsmanager:GetSecretValue`, `logs:CreateLogStream`, `logs:PutLogEvents`, and specific DynamoDB/MongoDB access if needed.
+   - **`AsharviBackendEcsExecutionRole`** – Allows `ecr:GetAuthorizationToken`, `ecr:BatchGetImage`, `logs:CreateLogStream`, and `logs:PutLogEvents`.
+   - **`AsharviCicdDeployRole`** (if reusing CI/CD) – Update trust relationship so GitHub Actions (or CodePipeline) can assume it. Attach least-privilege policy for ECR, ECS, CloudWatch, Secrets Manager.
+3. **Rotate credentials** – Rotate access keys for CI/CD IAM users/roles if older than 90 days. Document new keys in your CI/CD secrets storage.
+
+---
+
+## 2. Prepare Networking for the Backend
+1. **Create or validate VPC** (if the front end already uses one, ensure separation via subnets or new VPC):
+   - CIDR (e.g., `10.20.0.0/16`), with two public subnets and two private subnets across separate Availability Zones.
+   - Attach an Internet Gateway and create NAT Gateway(s) only if outbound internet is required from private subnets.
+2. **Security Groups**
+   - `alb-backend-sg`: inbound `443` from internet; outbound `3000` to ECS tasks.
+   - `ecs-backend-sg`: inbound `3000` from ALB SG; outbound `443` to Secrets Manager/ECR and `27017` or DynamoDB endpoints depending on the database choice.
+3. **VPC Endpoints** (optional but recommended): create interface endpoints for `com.amazonaws.ap-south-1.secretsmanager`, `ecr.api`, `ecr.dkr`, and `logs`. This allows ECS tasks to reach AWS services without traversing NAT.
+
+---
+
+## 3. Configure Secrets and Environment Values
+1. **AWS Secrets Manager**
+   - Create secret `asharvi/backend/prod` with JSON keys like `MONGO_URI` (or DynamoDB table name), `JWT_SECRET`, `SMTP_USER`, `SMTP_PASS`, `CORS_ORIGIN`.
+   - For staging, duplicate as `asharvi/backend/staging` with appropriate values.
+2. **Parameter Store (optional)**
+   - Store non-sensitive settings (log level, feature flags) as parameters.
+3. **Update IAM policies** to grant the ECS task role read access to these secrets/parameters only.
+
+---
+
+## 4. Provision Container Registry and Build Pipeline
+1. **Create ECR repositories**
+   - `asharvi-backend-staging`
+   - `asharvi-backend-prod`
+   - Enable image scanning and set lifecycle policies to retain the last N images (e.g., 20).
+2. **CI/CD pipeline**
+   - If using GitHub Actions, ensure repository secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `ECR_REPO`, `ECS_CLUSTER`, `ECS_SERVICE`) are updated.
+   - Pipeline stages: lint/test → build Docker image → push to ECR → update ECS service. Confirm IAM deploy role has permissions for these actions.
+
+---
+
+## 5. Set Up ECS Fargate Infrastructure
+1. **ECS Cluster** – Create `asharvi-backend-cluster` (Fargate). Enable Container Insights for monitoring.
+2. **Task Definitions**
+   - Use Node.js 18 image built from repository Dockerfile.
+   - CPU/memory recommendations: staging (0.5 vCPU/1 GB), production (1 vCPU/2 GB). Adjust per load tests.
+   - Configure container to listen on port `3000`. Add health check command hitting `/ready`.
+   - Inject secrets from Secrets Manager using `ValueFrom` references.
+   - Configure logging with awslogs to `/aws/ecs/asharvi-backend`.
+3. **ECS Services**
+   - Create separate services for staging and production with desired count ≥2 in different subnets.
+   - Enable circuit breaker and deployment minimum healthy percent of 100/200.
+   - Attach to corresponding target groups (created in the ALB step).
+   - Configure auto-scaling (scale out at 60% CPU/memory, scale in at 30%).
+
+---
+
+## 6. Application Load Balancer and Routing
+1. **Create ALB** `asharvi-backend-alb`
+   - Internet-facing, placed in public subnets.
+   - Listeners: HTTP (80) redirect to HTTPS (443), HTTPS (443) with ACM certificate (`api.example.com`).
+2. **Target Groups**
+   - Staging: `asharvi-backend-tg-stg` – health check path `/ready`.
+   - Production: `asharvi-backend-tg-prod` – same health check.
+3. **Route 53**
+   - Add `api.example.com` (prod) and `staging-api.example.com` records pointing to the ALB via alias.
+   - Use weighted or latency routing if needed.
+
+---
+
+## 7. Database Integration
+1. **MongoDB Atlas**
+   - Ensure Atlas cluster is located in ap-south-1. Configure VPC peering or PrivateLink to the AWS VPC and update route tables.
+   - Whitelist the ECS security group CIDR or specific private subnets.
+   - Confirm backup schedule and monitoring alerts are active.
+2. **If Migrating to DynamoDB**
+   - Create tables with partition keys aligned to application data model.
+   - Update secrets/parameters (`DYNAMO_TABLE_*` values) and modify application code accordingly before deployment.
+
+---
+
+## 8. Monitoring, Logging, and Alerts
+1. **CloudWatch Logs** – Verify log groups exist (`/aws/ecs/asharvi-backend-staging` and `/aws/ecs/asharvi-backend-prod`) with retention (e.g., 30 days).
+2. **CloudWatch Metrics & Alarms**
+   - Create dashboards tracking ALB target response time, ECS CPU/memory, task count, and custom application metrics if emitted.
+   - Set alarms for high 5xx errors, unhealthy host count, and scaling thresholds. Send notifications to existing SNS topics or create `asharvi-backend-alerts` topic.
+3. **Tracing (optional)** – Enable AWS X-Ray or third-party APM if deeper tracing is required. Grant task role necessary permissions.
+
+---
+
+## 9. Deployment and Validation Steps
+1. **First Deployment**
+   - Push code to staging branch; CI/CD pipeline should build, push image, update staging ECS service.
+   - Wait for tasks to pass health checks; confirm via `aws ecs describe-services` and ALB target group health.
+   - Run smoke tests against `https://staging-api.example.com/health-check`.
+2. **Production Rollout**
+   - Merge to `main` or trigger prod pipeline. Require manual approval if using GitHub environments.
+   - Monitor CloudWatch metrics and logs for anomalies during rollout. Use ECS deployment circuit breaker for automatic rollback on failures.
+3. **Post-Deployment Review**
+   - Validate IAM access logs for unusual activity.
+   - Ensure secrets rotation alarms are configured and documented.
+   - Review cost explorer for new backend resources to establish baseline spend.
+
+---
+
+## 10. Maintenance Checklist
+- Rotate Secrets Manager values and ECS task role credentials regularly.
+- Patch Docker base images monthly; update Dockerfile to latest Node.js LTS when available.
+- Review auto-scaling policies quarterly based on load trends.
+- Test disaster recovery by simulating MongoDB outages and verifying application behavior.
+- Document runbooks for incident response, scaling changes, and deployment rollback procedures.
+

--- a/scripts/setup_backend_infra.sh
+++ b/scripts/setup_backend_infra.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script provisions/updates backend IAM roles used by the Asharvi stack and
+# optionally rotates CI/CD access keys. It relies on AWS CLI v2 and jq.
+
+usage() {
+  cat <<'USAGE'
+Usage: setup_backend_infra.sh [options]
+
+Options:
+  -r, --region <aws-region>            AWS region (default: ap-south-1)
+  --github-org <org>                   GitHub organisation for CI/CD role trust (required for GitHub OIDC)
+  --github-repo <repo>                 GitHub repository for CI/CD role trust (required for GitHub OIDC)
+  --cicd-iam-user <username>           IAM user whose access keys should be rotated (optional)
+  --rotate                             Rotate access keys for the specified CI/CD IAM user
+  --dynamodb-table-arn <arn>           Optional DynamoDB table ARN to include in task role policy
+  --secrets-prefix <arn-prefix>        Secrets Manager ARN prefix (default: arn:aws:secretsmanager:*:*:secret:asharvi/backend/*)
+  --log-group-arn <arn>                CloudWatch Logs log-group ARN pattern (default: arn:aws:logs:*:*:log-group:/aws/ecs/asharvi-backend*)
+  -h, --help                           Show this help message
+
+Examples:
+  ./scripts/setup_backend_infra.sh --github-org Asharvi --github-repo backend-api \
+    --cicd-iam-user asharvi-deployer --rotate
+
+Notes:
+  * AWS credentials with iam:* permissions are required.
+  * When --rotate is used, the script outputs new access keys to STDOUT; store
+    them securely and remove from terminal history.
+USAGE
+}
+
+log() {
+  echo "[$(date +"%Y-%m-%dT%H:%M:%S%z")] $*"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: required command '$1' not found" >&2
+    exit 1
+  fi
+}
+
+ensure_role() {
+  local role_name="$1"
+  local assume_policy="$2"
+  local policy_name="$3"
+  local policy_document="$4"
+
+  if aws iam get-role --role-name "$role_name" >/dev/null 2>&1; then
+    log "Role $role_name exists; updating trust policy and inline policy"
+    aws iam update-assume-role-policy --role-name "$role_name" --policy-document "$assume_policy" >/dev/null
+  else
+    log "Creating role $role_name"
+    aws iam create-role --role-name "$role_name" \
+      --assume-role-policy-document "$assume_policy" \
+      --description "Backend infrastructure role created by setup_backend_infra.sh" >/dev/null
+  fi
+
+  # Put inline policy (idempotent; overwrites existing policy with same name)
+  aws iam put-role-policy --role-name "$role_name" --policy-name "$policy_name" --policy-document "$policy_document" >/dev/null
+}
+
+rotate_access_keys() {
+  local user="$1"
+
+  log "Rotating access keys for IAM user $user"
+  local keys_json
+  keys_json=$(aws iam list-access-keys --user-name "$user")
+  local active_keys
+  active_keys=$(echo "$keys_json" | jq -r '.AccessKeyMetadata[].AccessKeyId')
+
+  local new_key_json
+  new_key_json=$(aws iam create-access-key --user-name "$user")
+  local new_key_id new_secret
+  new_key_id=$(echo "$new_key_json" | jq -r '.AccessKey.AccessKeyId')
+  new_secret=$(echo "$new_key_json" | jq -r '.AccessKey.SecretAccessKey')
+
+  for key_id in $active_keys; do
+    if [[ "$key_id" != "$new_key_id" ]]; then
+      log "Deactivating old key $key_id"
+      aws iam update-access-key --user-name "$user" --access-key-id "$key_id" --status Inactive >/dev/null
+      log "Deleting old key $key_id"
+      aws iam delete-access-key --user-name "$user" --access-key-id "$key_id" >/dev/null
+    fi
+  done
+
+  cat <<EOF
+New access key created for $user
+  AWS_ACCESS_KEY_ID=$new_key_id
+  AWS_SECRET_ACCESS_KEY=$new_secret
+Store these credentials securely (e.g., GitHub Actions secrets) and remove them from console history.
+EOF
+}
+
+main() {
+  local region="ap-south-1"
+  local github_org=""
+  local github_repo=""
+  local cicd_user=""
+  local rotate="false"
+  local dynamodb_table_arn=""
+  local secrets_prefix="arn:aws:secretsmanager:*:*:secret:asharvi/backend/*"
+  local log_group_arn="arn:aws:logs:*:*:log-group:/aws/ecs/asharvi-backend*"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -r|--region)
+        region="$2"; shift 2 ;;
+      --github-org)
+        github_org="$2"; shift 2 ;;
+      --github-repo)
+        github_repo="$2"; shift 2 ;;
+      --cicd-iam-user)
+        cicd_user="$2"; shift 2 ;;
+      --rotate)
+        rotate="true"; shift 1 ;;
+      --dynamodb-table-arn)
+        dynamodb_table_arn="$2"; shift 2 ;;
+      --secrets-prefix)
+        secrets_prefix="$2"; shift 2 ;;
+      --log-group-arn)
+        log_group_arn="$2"; shift 2 ;;
+      -h|--help)
+        usage; exit 0 ;;
+      *)
+        echo "Unknown option: $1" >&2
+        usage
+        exit 1 ;;
+    esac
+  done
+
+  export AWS_REGION="$region"
+
+  require_command aws
+  require_command jq
+
+  log "Using region: $region"
+
+  local account_id
+  account_id=$(aws sts get-caller-identity --query 'Account' --output text)
+  log "Detected account: $account_id"
+
+  # Assemble assume role policies
+  local task_assume_policy
+  task_assume_policy=$(cat <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+)
+
+  local execution_assume_policy="$task_assume_policy"
+
+  # Task role inline policy
+  local task_statements
+  task_statements=$(cat <<EOF
+[
+  {
+    "Effect": "Allow",
+    "Action": ["secretsmanager:GetSecretValue"],
+    "Resource": ["$secrets_prefix"]
+  },
+  {
+    "Effect": "Allow",
+    "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
+    "Resource": ["$log_group_arn:*"]
+  }
+EOF
+)
+
+  if [[ -n "$dynamodb_table_arn" ]]; then
+    task_statements=$(cat <<EOF
+$task_statements,
+  {
+    "Effect": "Allow",
+    "Action": ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem", "dynamodb:Query", "dynamodb:Scan"],
+    "Resource": ["$dynamodb_table_arn"]
+  }
+EOF
+)
+  fi
+
+  task_statements+=$'\n]'
+
+  local task_policy
+  task_policy=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": $task_statements
+}
+EOF
+)
+
+  ensure_role "AsharviBackendEcsTaskRole" "$task_assume_policy" "AsharviBackendTaskPolicy" "$task_policy"
+
+  # Execution role policy
+  local execution_policy
+  execution_policy=$(cat <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
+      "Resource": "arn:aws:logs:*:*:log-group:/aws/ecs/*"
+    }
+  ]
+}
+EOF
+)
+
+  ensure_role "AsharviBackendEcsExecutionRole" "$execution_assume_policy" "AsharviBackendExecutionPolicy" "$execution_policy"
+
+  # CI/CD deploy role updates (if requested)
+  if [[ -n "$github_org" && -n "$github_repo" ]]; then
+    local cicd_role="AsharviCicdDeployRole"
+    log "Updating trust relationship for $cicd_role"
+    local trust_policy
+    trust_policy=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::$account_id:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:$github_org/$github_repo:*"
+        }
+      }
+    }
+  ]
+}
+EOF
+)
+
+    if aws iam get-role --role-name "$cicd_role" >/dev/null 2>&1; then
+      aws iam update-assume-role-policy --role-name "$cicd_role" --policy-document "$trust_policy" >/dev/null
+      log "Applied GitHub OIDC trust to $cicd_role"
+
+      local deploy_policy
+      deploy_policy=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeServices",
+        "ecs:UpdateService",
+        "ecs:RegisterTaskDefinition",
+        "ecs:DescribeTaskDefinition"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["iam:PassRole"],
+      "Resource": [
+        "arn:aws:iam::$account_id:role/AsharviBackendEcsExecutionRole",
+        "arn:aws:iam::$account_id:role/AsharviBackendEcsTaskRole"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:CompleteLayerUpload",
+        "ecr:DescribeImages",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:InitiateLayerUpload",
+        "ecr:PutImage",
+        "ecr:UploadLayerPart"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["secretsmanager:GetSecretValue"],
+      "Resource": ["$secrets_prefix"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["logs:DescribeLogGroups"],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+)
+
+      aws iam put-role-policy --role-name "$cicd_role" --policy-name AsharviCicdDeployPermissions --policy-document "$deploy_policy" >/dev/null
+      log "Updated inline policy for $cicd_role"
+    else
+      log "Warning: $cicd_role does not exist; skipping trust update"
+    fi
+  fi
+
+  if [[ "$rotate" == "true" ]]; then
+    if [[ -z "$cicd_user" ]]; then
+      echo "Error: --rotate requires --cicd-iam-user" >&2
+      exit 1
+    fi
+    rotate_access_keys "$cicd_user"
+  fi
+
+  log "Backend IAM setup complete"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a reusable Bash script that provisions backend ECS task/execution roles and updates the CI/CD deploy role
- support optional DynamoDB access, GitHub OIDC trust, and CI/CD credential rotation within the script

## Testing
- bash -n scripts/setup_backend_infra.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69051d5054e4832a85ba50648a4f8e35)